### PR TITLE
fix(numbering): renumber availability gating to IEP-19

### DIFF
--- a/ieps/18-metaldata.md
+++ b/ieps/18-metaldata.md
@@ -1,7 +1,7 @@
 ---
 title: Metaldata Service
 
-ep-number: 18
+iep-number: 18
 
 creation-date: 2026-03-30
 

--- a/ieps/19-availability-gating.md
+++ b/ieps/19-availability-gating.md
@@ -1,7 +1,7 @@
 ---
 title: Introducing ServerReadinessRule to ensure Server readiness
 
-iep-number: 0014
+iep-number: 19
 
 creation-date: 2026-04-27
 
@@ -14,7 +14,7 @@ reviewers:
   - '@ironcore-dev/metal-operator-maintainers'
 ---
 
-# IEP-0014: Availability Gating for IronCore Servers
+# IEP-19: Availability Gating for IronCore Servers
 
 ## Table of Contents
 


### PR DESCRIPTION
There were 2x IEP-14.

Consolidating the front-matter numbering too.
